### PR TITLE
Mitigate bug in libsndfile which causes problems reading raw IQ files.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664687381,
-        "narHash": "sha256-9czSuDzS+OGGwq2kC4KXBLXWfYaup+oLB+AA1Md25U4=",
+        "lastModified": 1665940183,
+        "narHash": "sha256-cPe3F7CtnxU9YbJpc3Adl4d9kX+turqTv5FxM98i8vg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59d2991d4256cdca1c0cda45d876c80a0fe45c31",
+        "rev": "104e8082de1b20f9d0e1f05b1028795ed0e0e4bc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "SDR related Nix packages";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
   

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,31 @@
   
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem ["x86_64-linux" "aarch64-linux"] (system: 
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in 
+        # use newer libsndfile version to mitigate this bug in libsndfile
+        # https://github.com/BatchDrake/SigDigger/issues/182
+        no-overlay-pkgs = import nixpkgs { inherit system; };
+        pkgs = if no-overlay-pkgs.libsndfile.version == "1.1.0" then
+          import nixpkgs {
+            inherit system;
+            overlays = [
+              (_self: super: {
+                libsndfile = super.libsndfile.overrideAttrs (oldAttrs: rec {
+                  version = "53e7dee23435f16671e00a22ab1277624bae6f8e";
+                  src = super.fetchFromGitHub {
+                    owner = oldAttrs.pname;
+                    repo = oldAttrs.pname;
+                    rev = version;
+                    sha256 = "sha256-tw7xnfg8Q6PNyaJfqcYtlmUIL4kJcspZdmoM+ic4kv4=";
+                  };
+                });
+              })
+            ];
+          }
+        else
+          no-overlay-pkgs;
+      in
       {
         packages.hackrf = pkgs.hackrf;
         packages.hackrf-firmware-hackrf-one = pkgs.callPackage ./hackrf-firmware.nix { 


### PR DESCRIPTION
See [here](https://github.com/BatchDrake/SigDigger/issues/182).